### PR TITLE
The KSL server response for listing objects now uses `displayTime` instead of `createTime`

### DIFF
--- a/ksl.py
+++ b/ksl.py
@@ -92,8 +92,7 @@ class KSL(object):
             if 'price' not in ad_box:
                 # Free items are missing the price
                 ad_box['price'] = 0
-
-            created = (datetime.strptime(ad_box['createTime'],
+            created = (datetime.strptime(ad_box['displayTime'],
                                          "%Y-%m-%dT%H:%M:%SZ")
                        + self.time_offset)
             lifespan = str(created)


### PR DESCRIPTION
The KSL server response for listing objects now uses `displayTime` in place of `createTime`. Without this update, the KSL notifier crashes.